### PR TITLE
Fix AddonManager/FileUtils imports

### DIFF
--- a/userChrome.js
+++ b/userChrome.js
@@ -18,6 +18,12 @@ be modified when you are in root/admin mode.
 // https://mike.kaply.com/2016/09/08/debugging-firefox-autoconfig-problems/
 lockPref("a.b.c.d", "1.2.3.4"); // Debugging Firefox AutoConfig Problems
 
+const { AddonManager } =
+ChromeUtils.importESModule("resource://gre/modules/AddonManager.sys.mjs");
+//find the modules here: https://searchfox.org/mozilla-central/source/toolkit/modules
+const { FileUtils } =
+ChromeUtils.importESModule("resource://gre/modules/FileUtils.sys.mjs");
+
 // userChrome.js file for [Firefox program folder]
 // file name must match the name in [Firefox program folder]\defaults\pref
 
@@ -107,12 +113,6 @@ try {
 	  // "AddonManager is not initialized"
 	  Services.obs.addObserver(this, 'final-ui-startup', false);
   }
-
-  const { AddonManager } =
-	  Components.utils.import("resource://gre/modules/AddonManager.jsm");
-
-  const { FileUtils } =
-	  Components.utils.import("resource://gre/modules/FileUtils.jsm");
 
   ConfigJS.prototype = {
 


### PR DESCRIPTION
The script has stopped working ever since I updated Firefox Developer Edition from v135.0 to 136.0a2

The error in the browser console was "Components.utils.import is not a function"

An alternative way to import AddonManager and FileUtils is with ChromeUtils.importESModule, and by specifying the filename of the module .mjs file found here: https://searchfox.org/mozilla-central/source/toolkit/modules

Also, the import for FileUtils needs to be hoisted out of the try block as otherwise the browser errors that FileUtils isn't defined (not sure why this didn't error before I updated)

If this PR is merged along with #3 then the script works again (at least for me)

Also this script has been really helpful for my setup. Thanks for releasing it!